### PR TITLE
Add bower dependency and update main references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+bower_components
 npm-debug.log

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "braintree-angular",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/jeffcarp/braintree-angular",
   "authors": [
     "Braintree <code@getbraintree.com>"
   ],
   "description": "Use Braintree in your Angular app",
-  "main": "index.js",
+  "main": "dist/braintree-angular.js",
   "keywords": [
     "braintree",
     "angular"
@@ -15,5 +15,8 @@
   "ignore": [
     "**/.*",
     "!dist/braintree-angular.js"
-  ]
+  ],
+  "dependencies": {
+    "braintree-web": "2.5.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "braintree-angular",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Use Braintree in your Angular app",
-  "main": "index.js",
+  "main": "dist/braintree-angular.js",
   "scripts": {
     "test": "npm run build && mocha spec/integration",
     "build": "browserify index.js > dist/braintree-angular.js"


### PR DESCRIPTION
The bower dependency is needed if you are installing without npm.
I updated the main key from `index` to `dist/braintree-angular.js` so that wiredep would automatically link the dependencies in my app.