### PR TITLE
Force restrict 'AEC' on directives

### DIFF
--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -61,6 +61,7 @@ braingular.factory('$braintree', braintreeFactory.fullBraintreeFactory);
 braingular.directive('braintreeDropin', function() {
   return {
     scope: {
+      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-dropin"></div>',
@@ -76,6 +77,7 @@ braingular.directive('braintreeDropin', function() {
 braingular.directive('braintreePaypal', function() {
   return {
     scope: {
+      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-paypal"></div>',

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -60,8 +60,8 @@ braingular.factory('$braintree', braintreeFactory.fullBraintreeFactory);
 
 braingular.directive('braintreeDropin', function() {
   return {
+    restrict: 'AEC',
     scope: {
-      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-dropin"></div>',
@@ -76,8 +76,8 @@ braingular.directive('braintreeDropin', function() {
 
 braingular.directive('braintreePaypal', function() {
   return {
+    restrict: 'AEC',
     scope: {
-      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-paypal"></div>',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ braingular.factory('$braintree', braintreeFactory.fullBraintreeFactory);
 braingular.directive('braintreeDropin', function() {
   return {
     scope: {
+      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-dropin"></div>',
@@ -21,6 +22,7 @@ braingular.directive('braintreeDropin', function() {
 braingular.directive('braintreePaypal', function() {
   return {
     scope: {
+      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-paypal"></div>',

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ braingular.factory('$braintree', braintreeFactory.fullBraintreeFactory);
 
 braingular.directive('braintreeDropin', function() {
   return {
+    restrict: 'AEC',
     scope: {
-      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-dropin"></div>',
@@ -21,8 +21,8 @@ braingular.directive('braintreeDropin', function() {
 
 braingular.directive('braintreePaypal', function() {
   return {
+    restrict: 'AEC',
     scope: {
-      restrict: 'AEC',
       options: '='
     },
     template: '<div id="bt-paypal"></div>',


### PR DESCRIPTION
If Angular <= 1.2 default directive is 'A' only. Fixes #17