### PR TITLE
Add support for customerId in clientToken request

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Client tokens are generated with your Braintree server library. Here are guides 
 
 </form>
 ```
+If you are using Braintree subscriptions you may need to pass a customerId to your server when creating a client token. You can add the customerId as a parameter to  braintree-dropin like this: `<braintree-dropin customer-id='yourCustomerId'></braintree-dropin>`. A query string will be appended to the url defined in the clientTokenPath constant like this: `/client-token?customerId=yourCustomerId`.
 
 ```javascript
 angular.module('example', ['braintree-angular'])

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -20,14 +20,15 @@ braingular.directive('braintreeDropin', function() {
   return {
     restrict: 'AEC',
     scope: {
-      options: '='
+      options: '=',
+      clientTokenQueryString: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
+      var queryString = $scope.clientTokenQueryString || null;
       options.container = 'bt-dropin';
-
-      $braintree.setupDropin(options);
+      $braintree.setupDropin(options, queryString);
     }]
   }
 });
@@ -61,23 +62,13 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (params) {
-      var path = clientTokenPath;
-
-      if (params) {
-        // TODO: Use a library for this
-        path += '?';
-        path += Object.keys(params).map(function (key) {
-          var value = params[key];
-          return key + '=' + value
-        }).join('&');
-      }
-
+    $braintree.getClientToken = function (queryString) {
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
       return $http.get(path);
     }
 
-    $braintree.setupDropin = function(options) {
-      $braintree.getClientToken()
+    $braintree.setupDropin = function(options, queryString) {
+      $braintree.getClientToken(queryString)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -21,12 +21,12 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      clientTokenQueryString: '='
+      customerId: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
-      var queryString = $scope.clientTokenQueryString || null;
+      var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
       $braintree.setupDropin(options, queryString);
     }]
@@ -62,18 +62,18 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (queryString) {
-      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+    $braintree.getClientToken = function (path) {
       return $http.get(path);
     }
 
     $braintree.setupDropin = function(options, queryString) {
-      $braintree.getClientToken(queryString)
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+      $braintree.getClientToken(path)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })
         .error(function(data, status) {
-          console.error('error fetching client token at '+clientTokenPath, data, status);
+          console.error('error fetching client token at '+path, data, status);
         });
     };
 

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -14,14 +14,15 @@ braingular.directive('braintreeDropin', function() {
   return {
     restrict: 'AEC',
     scope: {
-      options: '='
+      options: '=',
+      clientTokenQueryString: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
+      var queryString = $scope.clientTokenQueryString || null;
       options.container = 'bt-dropin';
-
-      $braintree.setupDropin(options);
+      $braintree.setupDropin(options, queryString);
     }]
   }
 });

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -15,12 +15,12 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      clientTokenQueryString: '='
+      customerId: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
-      var queryString = $scope.clientTokenQueryString || null;
+      var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
       $braintree.setupDropin(options, queryString);
     }]

--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -8,18 +8,18 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (queryString) {
-      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+    $braintree.getClientToken = function (path) {
       return $http.get(path);
     }
 
     $braintree.setupDropin = function(options, queryString) {
-      $braintree.getClientToken(queryString)
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+      $braintree.getClientToken(path)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })
         .error(function(data, status) {
-          console.error('error fetching client token at '+clientTokenPath, data, status);
+          console.error('error fetching client token at '+path, data, status);
         });
     };
 

--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -8,23 +8,13 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (params) {
-      var path = clientTokenPath;
-
-      if (params) {
-        // TODO: Use a library for this
-        path += '?';
-        path += Object.keys(params).map(function (key) {
-          var value = params[key];
-          return key + '=' + value
-        }).join('&');
-      }
-
+    $braintree.getClientToken = function (queryString) {
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
       return $http.get(path);
     }
 
-    $braintree.setupDropin = function(options) {
-      $braintree.getClientToken()
+    $braintree.setupDropin = function(options, queryString) {
+      $braintree.getClientToken(queryString)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "homepage": "https://github.com/jeffcarp/braintree-angular",
   "dependencies": {
-    "braintree-web": "2.7.2"
+    "braintree-web": "2.7.2",
+    "dnode-protocol": "^0.2.2",
+    "mime-db": "^1.20.0",
+    "sockjs": "^0.3.15"
   },
   "devDependencies": {
     "angular": "^1.3.3",


### PR DESCRIPTION
I am trying to use the library to create subscriptions. I ran across a stumbling block which is that I need a customerId in the server to create a clientToken for a subscription. I have just added a `customerId` parameter to the braintree-dropin directive and passed that through to the server as a query parameter.

In the process, I noticed that there was a test for a similar feature and some (apparently partially implemented) code. 

Please feel free to scrap this pull request if you are implementing something more comprehensive :), but this seems to be working for me.

Sorry I didn't update the tests because I couldn't get them to run on my system and didn't have time to fight with them