### PR TITLE
Update braintree web version and add a parameter for on-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Client tokens are generated with your Braintree server library. Here are guides 
 ```
 If you are using Braintree subscriptions you may need to pass a customerId to your server when creating a client token. You can add the customerId as a parameter to  braintree-dropin like this: `<braintree-dropin customer-id='yourCustomerId'></braintree-dropin>`. A query string will be appended to the url defined in the clientTokenPath constant like this: `/client-token?customerId=yourCustomerId`.
 
+To be notified when the Braintree integration is ready, use `<braintree-dropin on-ready-flag='yourBooleanFlag'></braintree-dropin>`. The flag will be set to `true` when the dropin has loaded.
+
+
 ```javascript
 angular.module('example', ['braintree-angular'])
   .constant('clientTokenPath', '/client-token');

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Client tokens are generated with your Braintree server library. Here are guides 
 
 </form>
 ```
+If you are using Braintree subscriptions you may need to pass a customerId to your server when creating a client token. You can add the customerId as a parameter to  braintree-dropin like this: `<braintree-dropin customer-id='yourCustomerId'></braintree-dropin>`. A query string will be appended to the url defined in the clientTokenPath constant like this: `/client-token?customerId=yourCustomerId`.
 
 ```javascript
 angular.module('example', ['braintree-angular'])

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -28,8 +28,6 @@ braingular.directive('braintreeDropin', function() {
       var options = $scope.options || {};
       var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
-      options.onPaymentMethodReceived = function (obj) {console.log("Braintree paymentMethodReceived:", obj)}
-      options.onReady = function(obj){console.log("Braintree ready:", obj)}
       $braintree.setupDropin(options, queryString);
     }]
   }
@@ -45,6 +43,7 @@ braingular.directive('braintreePaypal', function() {
     controller: function($scope, $braintree) {
       var options = $scope.options || {};
       options.container = 'bt-paypal';
+
       $braintree.setupPayPal(options);
     }
   }

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -28,6 +28,8 @@ braingular.directive('braintreeDropin', function() {
       var options = $scope.options || {};
       var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
+      options.onPaymentMethodReceived = function (obj) {console.log("Braintree paymentMethodReceived:", obj)}
+      options.onReady = function(obj){console.log("Braintree ready:", obj)}
       $braintree.setupDropin(options, queryString);
     }]
   }
@@ -43,7 +45,6 @@ braingular.directive('braintreePaypal', function() {
     controller: function($scope, $braintree) {
       var options = $scope.options || {};
       options.container = 'bt-paypal';
-
       $braintree.setupPayPal(options);
     }
   }

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -20,14 +20,15 @@ braingular.directive('braintreeDropin', function() {
   return {
     restrict: 'AEC',
     scope: {
-      options: '='
+      options: '=',
+      clientTokenQueryString: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
+      var queryString = $scope.clientTokenQueryString || null;
       options.container = 'bt-dropin';
-
-      $braintree.setupDropin(options);
+      $braintree.setupDropin(options, queryString);
     }]
   }
 });
@@ -61,23 +62,13 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (params) {
-      var path = clientTokenPath;
-
-      if (params) {
-        // TODO: Use a library for this
-        path += '?';
-        path += Object.keys(params).map(function (key) {
-          var value = params[key];
-          return key + '=' + value
-        }).join('&');
-      }
-
+    $braintree.getClientToken = function (queryString) {
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
       return $http.get(path);
     }
 
-    $braintree.setupDropin = function(options) {
-      $braintree.getClientToken()
+    $braintree.setupDropin = function(options, queryString) {
+      $braintree.getClientToken(queryString)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -21,13 +21,19 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      customerId: '='
+      customerId: '=',
+      onReadyFlag: '='
     },
     template: '<div id="bt-dropin"></div>',
-    controller: ['$scope', '$braintree', function($scope, $braintree) {
+    controller: ['$scope', '$braintree','$timeout', function($scope, $braintree, $timeout) {
       var options = $scope.options || {};
       var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
+      options.onReady = function(){
+        $timeout(function(){
+          $scope.onReadyFlag = true;
+        })
+      }
       $braintree.setupDropin(options, queryString);
     }]
   }

--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -21,12 +21,12 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      clientTokenQueryString: '='
+      customerId: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
-      var queryString = $scope.clientTokenQueryString || null;
+      var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
       $braintree.setupDropin(options, queryString);
     }]
@@ -62,18 +62,18 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (queryString) {
-      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+    $braintree.getClientToken = function (path) {
       return $http.get(path);
     }
 
     $braintree.setupDropin = function(options, queryString) {
-      $braintree.getClientToken(queryString)
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+      $braintree.getClientToken(path)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })
         .error(function(data, status) {
-          console.error('error fetching client token at '+clientTokenPath, data, status);
+          console.error('error fetching client token at '+path, data, status);
         });
     };
 

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -14,14 +14,15 @@ braingular.directive('braintreeDropin', function() {
   return {
     restrict: 'AEC',
     scope: {
-      options: '='
+      options: '=',
+      clientTokenQueryString: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
+      var queryString = $scope.clientTokenQueryString || null;
       options.container = 'bt-dropin';
-
-      $braintree.setupDropin(options);
+      $braintree.setupDropin(options, queryString);
     }]
   }
 });

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -15,12 +15,12 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      clientTokenQueryString: '='
+      customerId: '='
     },
     template: '<div id="bt-dropin"></div>',
     controller: ['$scope', '$braintree', function($scope, $braintree) {
       var options = $scope.options || {};
-      var queryString = $scope.clientTokenQueryString || null;
+      var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
       $braintree.setupDropin(options, queryString);
     }]

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -15,13 +15,19 @@ braingular.directive('braintreeDropin', function() {
     restrict: 'AEC',
     scope: {
       options: '=',
-      customerId: '='
+      customerId: '=',
+      onReadyFlag: '='
     },
     template: '<div id="bt-dropin"></div>',
-    controller: ['$scope', '$braintree', function($scope, $braintree) {
+    controller: ['$scope', '$braintree','$timeout', function($scope, $braintree, $timeout) {
       var options = $scope.options || {};
       var queryString = $scope.customerId ? "customerId="+$scope.customerId : null;
       options.container = 'bt-dropin';
+      options.onReady = function(){
+        $timeout(function(){
+          $scope.onReadyFlag = true;
+        })
+      }
       $braintree.setupDropin(options, queryString);
     }]
   }

--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -8,18 +8,18 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (queryString) {
-      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+    $braintree.getClientToken = function (path) {
       return $http.get(path);
     }
 
     $braintree.setupDropin = function(options, queryString) {
-      $braintree.getClientToken(queryString)
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
+      $braintree.getClientToken(path)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })
         .error(function(data, status) {
-          console.error('error fetching client token at '+clientTokenPath, data, status);
+          console.error('error fetching client token at '+path, data, status);
         });
     };
 

--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -8,23 +8,13 @@ function braintreeFactory(braintree) {
       $braintree[key] = braintree[key];
     });
 
-    $braintree.getClientToken = function (params) {
-      var path = clientTokenPath;
-
-      if (params) {
-        // TODO: Use a library for this
-        path += '?';
-        path += Object.keys(params).map(function (key) {
-          var value = params[key];
-          return key + '=' + value
-        }).join('&');
-      }
-
+    $braintree.getClientToken = function (queryString) {
+      var path = queryString ? clientTokenPath+'?'+queryString : clientTokenPath;
       return $http.get(path);
     }
 
-    $braintree.setupDropin = function(options) {
-      $braintree.getClientToken()
+    $braintree.setupDropin = function(options, queryString) {
+      $braintree.getClientToken(queryString)
         .success(function(token) {
           braintree.setup(token, 'dropin', options);
         })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "braintree-web": "2.7.2",
     "dnode-protocol": "^0.2.2",
     "mime-db": "^1.20.0",
-    "sockjs": "^0.3.15"
+    "sockjs": "^0.3.15",
+    "weak": "^1.0.0"
   },
   "devDependencies": {
     "angular": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "homepage": "https://github.com/jeffcarp/braintree-angular",
   "dependencies": {
-    "braintree-web": "2.7.2"
+    "braintree-web": "2.7.2",
+    "dnode-protocol": "^0.2.2",
+    "mime-db": "^1.20.0",
+    "sockjs": "^0.3.15"
   },
   "devDependencies": {
     "angular": "^1.3.3",


### PR DESCRIPTION
@jeffcarp `npm run build` does build the project but `npm run test` still fails for me.

I struggled to get the `onReady` callback to work for one reason or another. It seemed to clobber the context of the callback, so I couldn't get it to do anything useful. Could just have been me doing something stupid. In the process, I updated the version of braintree-web, in case that was the solution, as suggested in another issue. That didn't fix it.

I ended up solving the problem by adding a parameter `on-ready-flag` to the directive and a callback in the directive's controller to set the flag when the Braintree onReady callback is fired.

It's not elegant, but it was the only way I could get the job done - use it, don't use it :) .

