### PR TITLE
Properly use dependency injection syntax for braintree-paypal directive

### DIFF
--- a/dist/braintree-angular.js
+++ b/dist/braintree-angular.js
@@ -39,12 +39,12 @@ braingular.directive('braintreePaypal', function () {
       options: '='
     },
     template: '<div id="bt-paypal"></div>',
-    controller: function ($scope, $braintree) {
+    controller: ['$scope', '$braintree', function ($scope, $braintree) {
       var options = $scope.options || {}
       options.container = 'bt-paypal'
 
       $braintree.setupPayPal(options)
-    }
+    }]
   }
 })
 

--- a/lib/braintree-angular.js
+++ b/lib/braintree-angular.js
@@ -33,12 +33,12 @@ braingular.directive('braintreePaypal', function () {
       options: '='
     },
     template: '<div id="bt-paypal"></div>',
-    controller: function ($scope, $braintree) {
+    controller: ['$scope', '$braintree', function ($scope, $braintree) {
       var options = $scope.options || {}
       options.container = 'bt-paypal'
 
       $braintree.setupPayPal(options)
-    }
+    }]
   }
 })
 


### PR DESCRIPTION
Background: Having a rails application, deployed to heroku, and was seeing `Unknow eProvider` error when using the `<braintree-paypal>` directive. Looking back in the issues ticket, there was a <a href="https://github.com/jeffcarp/braintree-angular/issues/13#issuecomment-221393848">ticket</a> that discussed how `ng-strict-di` detected that `<braintree-dropin>` directive wasn't using the proper DI syntax and that was subsequently fixed. This is basically a followup to that to also address, oversight for the `<braintree-paypal>` directive.

FYI, as an outlier, this was a non issue in local development. 

I verified the fix by registering a separate bower library against a forked repo and that, when deployed was able to work out `braintree-angular-gamersensei` (forked repo bower library). Once this is in merged into mainstream, will switch out the forked bower library and again use the `braintree-angular` library.

Not sure, if this explicit way to change the `dist` file is correct or not. Is there a build process to generate the `dist/braintree-angular.js` file?