### PR TITLE
replace deprecated success/error $http methods

### DIFF
--- a/lib/braintree-factory.js
+++ b/lib/braintree-factory.js
@@ -25,21 +25,21 @@ function braintreeFactory (braintree) {
 
     $braintree.setupDropin = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'dropin', options)
+        .then(function (response) {
+          braintree.setup(response.data, 'dropin', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .catch(function (response) {
+          console.error('error fetching client token at ' + clientTokenPath, response.data, response.status)
         })
     }
 
     $braintree.setupPayPal = function (options) {
       $braintree.getClientToken()
-        .success(function (token) {
-          braintree.setup(token, 'paypal', options)
+        .then(function (response) {
+          braintree.setup(response.data, 'paypal', options)
         })
-        .error(function (data, status) {
-          console.error('error fetching client token at ' + clientTokenPath, data, status)
+        .catch(function (response) {
+          console.error('error fetching client token at ' + clientTokenPath, response.data, response.status)
         })
     }
 


### PR DESCRIPTION
with the upcoming angular 1.6, the `success`/`error` methods will be [removed](https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$http)